### PR TITLE
DEVOPS-591 warn users on deletion

### DIFF
--- a/cmd/ksec/delete.go
+++ b/cmd/ksec/delete.go
@@ -14,6 +14,16 @@ var deleteCmd = &cobra.Command{
 }
 
 func deleteCommand(cmd *cobra.Command, args []string) error {
+	skipconfirm, err := cmd.Flags().GetBool("yes")
+	if err != nil {
+		return err
+	}
+
+	if !skipconfirm && !askConfirmation("Are you sure? This action cannot be reversed.") {
+		fmt.Println("canceled")
+		return nil
+	}
+
 	for _, name := range args {
 		if err := secretsClient.Delete(name); err != nil {
 			return err

--- a/cmd/ksec/delete.go
+++ b/cmd/ksec/delete.go
@@ -19,6 +19,13 @@ func deleteCommand(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	for _, name := range args {
+		if _, err := secretsClient.Get(name); err != nil {
+			fmt.Println(err)
+			return nil
+		}
+	}
+
 	if !skipconfirm && !askConfirmation("Are you sure? This action cannot be reversed.") {
 		fmt.Println("canceled")
 		return nil

--- a/cmd/ksec/delete.go
+++ b/cmd/ksec/delete.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -21,17 +22,16 @@ func deleteCommand(cmd *cobra.Command, args []string) error {
 
 	for _, name := range args {
 		if _, err := secretsClient.Get(name); err != nil {
-			fmt.Println(err)
-			return nil
+			fmt.Fprintln(os.Stderr, err)
+			continue
 		}
-	}
 
-	if !skipconfirm && !askConfirmation("Are you sure? This action cannot be reversed.") {
-		fmt.Println("canceled")
-		return nil
-	}
+		confirmationMessage := fmt.Sprintf(`Delete secret "%s"? This action cannot be reversed.`, name)
+		if !skipconfirm && !askConfirmation(confirmationMessage) {
+			fmt.Println("Delete canceled")
+			continue
+		}
 
-	for _, name := range args {
 		if err := secretsClient.Delete(name); err != nil {
 			return err
 		}

--- a/cmd/ksec/main.go
+++ b/cmd/ksec/main.go
@@ -40,6 +40,9 @@ func initRootCmd(rootCmd *cobra.Command) {
 	rootCmd.AddCommand(getCmd)
 	getCmd.Flags().BoolP("verbose", "v", false, "Show extra metadata")
 
+	rootCmd.AddCommand(deleteCmd)
+	deleteCmd.Flags().BoolP("yes", "y", false, "do not ask for confirmation")
+
 	rootCmd.AddCommand(listCmd)
 	listCmd.Flags().BoolP("all", "a", false, "Show all secrets (Default: Opaque only)")
 

--- a/cmd/ksec/main.go
+++ b/cmd/ksec/main.go
@@ -30,7 +30,6 @@ func initRootCmd(rootCmd *cobra.Command) {
 
 	// subcommands without extra options
 	rootCmd.AddCommand(createCmd)
-	rootCmd.AddCommand(deleteCmd)
 	rootCmd.AddCommand(pullCmd)
 	rootCmd.AddCommand(pushCmd)
 	rootCmd.AddCommand(setCmd)

--- a/cmd/ksec/main_test.go
+++ b/cmd/ksec/main_test.go
@@ -74,7 +74,7 @@ func TestUnsetSecretKey(t *testing.T) {
 }
 
 func TestDeleteSecret(t *testing.T) {
-	err := cmdExec([]string{"delete", "test"})
+	err := cmdExec([]string{"delete", "test", "--yes"})
 	testErr(err, t)
 
 	err = cmdExec([]string{"get", "test"})

--- a/cmd/ksec/utils.go
+++ b/cmd/ksec/utils.go
@@ -22,7 +22,7 @@ func askConfirmation(message string) bool {
 	scanner.Scan()
 	response := scanner.Text()
 	if err := scanner.Err(); err != nil {
-		fmt.Fprintln(os.Stderr, "invalid input: ", err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 

--- a/cmd/ksec/utils.go
+++ b/cmd/ksec/utils.go
@@ -21,8 +21,9 @@ func askConfirmation(message string) bool {
 	scanner := bufio.NewScanner(os.Stdin)
 	scanner.Scan()
 	response := scanner.Text()
-	if scanner.Err() != nil {
-		return false
+	if err := scanner.Err(); err != nil {
+		fmt.Fprintln(os.Stderr, "invalid input: ", err)
+		os.Exit(1)
 	}
 
 	if response == "y" {

--- a/cmd/ksec/utils.go
+++ b/cmd/ksec/utils.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"text/tabwriter"
@@ -12,4 +13,21 @@ func outputTabular(lines []string) {
 		fmt.Fprintln(w, line)
 	}
 	w.Flush()
+}
+
+func askConfirmation(message string) bool {
+	fmt.Printf("%s [y/N]: ", message)
+
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Scan()
+	response := scanner.Text()
+	if scanner.Err() != nil {
+		return false
+	}
+
+	if response == "y" {
+		return true
+	}
+
+	return false
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version sets the release version for ksec
-const Version = "0.1.2"
+const Version = "0.1.3"


### PR DESCRIPTION
Sample usage:
```
booster 10gen-ops/ksec ‹redondos/DEVOPS-591*› » ksec delete angelo-test                                                                                                                                                                                                             (aws:platform)(k8s:test.k8s.local:devops)
Are you sure? This action cannot be reversed. (y/n) [n]:
booster 10gen-ops/ksec ‹redondos/DEVOPS-591*› » ksec delete angelo-test                                                                                                                                                                                                             (aws:platform)(k8s:test.k8s.local:devops)
Are you sure? This action cannot be reversed. (y/n) [n]: y
Deleted secret "angelo-test"
```

Test run (no changes):
```
booster 10gen-ops/ksec ‹redondos/DEVOPS-591*› » make test                                                                                                                                                                                                                           (aws:platform)(k8s:test.k8s.local:devops)
go vet ./...
go test -cover ./...
ok  	github.com/10gen-ops/ksec/cmd/ksec	(cached)	coverage: 54.7% of statements
ok  	github.com/10gen-ops/ksec/pkg/models	(cached)	coverage: 55.3% of statements
?   	github.com/10gen-ops/ksec/pkg/version	[no test files]
```