### PR TITLE
DEVOPS-1607 get specific key

### DIFF
--- a/cmd/ksec/get.go
+++ b/cmd/ksec/get.go
@@ -9,14 +9,26 @@ import (
 )
 
 var getCmd = &cobra.Command{
-	Use:   "get [secret]",
+	Use:   "get [secret] [key]",
 	Short: "Get values from a Secret",
-	Args:  cobra.ExactArgs(1),
+	Args:  cobra.RangeArgs(1, 2),
 	RunE:  getCommand,
 }
 
 func getCommand(cmd *cobra.Command, args []string) error {
-	secret, err := secretsClient.Get(args[0])
+	secretName := args[0]
+
+	if len(args) > 1 {
+		value, err := secretsClient.GetKey(secretName, args[1])
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(value)
+		return nil
+	}
+
+	secret, err := secretsClient.Get(secretName)
 	if err != nil {
 		return err
 	}

--- a/pkg/models/secrets_client.go
+++ b/pkg/models/secrets_client.go
@@ -104,6 +104,21 @@ func (s *SecretsClient) Get(name string) (*v1.Secret, error) {
 	return s.secretInterface.Get(name, metav1.GetOptions{})
 }
 
+// GetKey retrieves an individual keys value from a secret
+func (s *SecretsClient) GetKey(name, key string) (string, error) {
+	secret, err := s.Get(name)
+	if err != nil {
+		return "", err
+	}
+
+	value, ok := secret.Data[key]
+	if !ok {
+		return "", fmt.Errorf("secret key %s does not exist", key)
+	}
+
+	return string(value), nil
+}
+
 // Update Secret keys
 func (s *SecretsClient) Update(secret *v1.Secret, data map[string][]byte) (*v1.Secret, error) {
 	if secret.Data == nil {

--- a/pkg/models/secrets_client_test.go
+++ b/pkg/models/secrets_client_test.go
@@ -63,6 +63,20 @@ func TestGet(t *testing.T) {
 	}
 }
 
+func TestGetKey(t *testing.T) {
+	value, err := secretsClient.GetKey("test-secret-with-data", "secret-key")
+	testErr(err, t)
+
+	if value != "secret-value" {
+		t.Fatal(err.Error())
+	}
+
+	value, err = secretsClient.GetKey("test-secret-with_data", "thiskeydoesnotexist")
+	if err == nil {
+		t.Fatal("non-existent key should have received an error")
+	}
+}
+
 func TestUpdate(t *testing.T) {
 	secret, err := secretsClient.Get("test-secret-with-data")
 	testErr(err, t)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version sets the release version for ksec
-const Version = "0.1.2"
+const Version = "0.1.3"


### PR DESCRIPTION
Update `ksec get` to also retrieve a specific secret key.

```
$ ksec get test-secret
KEY VALUE
key value

$ ksec get test-secret key
value
```

FYI @macintacos