### PR TITLE
DEVOPS-2198 updating install scripts to support helm 3

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,6 @@
 ---
 kind: pipeline
-type: kubernetes
+type: docker
 name: default
 
 steps:

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,12 @@
+---
+kind: pipeline
+type: kubernetes
+name: default
+
+steps:
+  - name: test
+    image: golangci/golangci-lint:v1.30.0-alpine
+    commands:
+      - apk update
+      - apk add make
+      - make test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ksec
 
+[![Build Status](https://cloud.drone.io/api/badges/10gen-ops/ksec/status.svg)](https://cloud.drone.io/10gen-ops/ksec)
+
 A command line tool that simplifies the management of Kubernetes Secrets.
 
 ## Installation

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,8 +1,9 @@
 name: "ksec"
+version: "0.1.3"
 usage: "Manage Kubernetes Secrets through Helm"
 description: "Helm plugin that simplifies the management of Kubernetes Secrets"
 ignoreFlags: false
 useTunnel: false
 command: "$HELM_PLUGIN_DIR/ksec"
 hooks:
-  install: "$HELM_PLUGIN_DIR/scripts/install-binary.sh"
+  install: "cd $HELM_PLUGIN_DIR; scripts/install-binary.sh"

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -6,4 +6,4 @@ ignoreFlags: false
 useTunnel: false
 command: "$HELM_PLUGIN_DIR/ksec"
 hooks:
-  install: "cd $HELM_PLUGIN_DIR; scripts/install-binary.sh"
+  install: "cd $HELM_PLUGIN_DIR && scripts/install-binary.sh"

--- a/scripts/install-binary.sh
+++ b/scripts/install-binary.sh
@@ -1,15 +1,20 @@
 #!/usr/bin/env bash
 
+if [ -n "${HELM_LINTER_PLUGIN_NO_INSTALL_HOOK}" ]; then
+    echo "Development mode: not downloading versioned release."
+    exit 0
+fi
+
 PROJECT_NAME="ksec"
 PROJECT_GH="10gen-ops/$PROJECT_NAME"
 
-: ${HELM_PLUGIN_PATH:="$(helm home)/plugins/${PROJECT_NAME}"}
+: ${HELM_PLUGIN_PATH:="$(pwd)/${PROJECT_NAME}"}
 
 # Convert the HELM_PLUGIN_PATH to unix if cygpath is
 # available. This is the case when using MSYS2 or Cygwin
 # on Windows where helm returns a Windows path but we
 # need a Unix path
-if type cygpath > /dev/null; then
+if type cygpath 2> /dev/null; then
   HELM_PLUGIN_PATH=$(cygpath -u $HELM_PLUGIN_PATH)
 fi
 
@@ -109,7 +114,7 @@ fail_trap() {
 # testVersion tests the installed client to make sure it is working.
 testVersion() {
   set +e
-  echo "$PROJECT_NAME installed into $HELM_PLUGIN_PATH/$PROJECT_NAME"
+  echo "$PROJECT_NAME installed into $HELM_PLUGIN_PATH"
   # To avoid to keep track of the Windows suffix,
   # call the plugin assuming it is in the PATH
   PATH=$PATH:$HELM_PLUGIN_PATH


### PR DESCRIPTION
I updated the install scripts to remove the dependency on `helm home` which is deprecated in helm v3.  

This is simply using the `$HELM_PLUGIN_DIR` environment variable that is supported in both versions of helm.  

The change is backwards compatible to helm 2.  It was tested running the following commands:

```
helm2 plugin install .
helm plugin install .
```
