### PR TITLE
Feature M1 Builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,9 @@ dist:
 	GOOS=linux GOARCH=amd64 go build -o ksec ./cmd/ksec/
 	tar -zcvf $(DIST)/ksec-linux-$(VERSION).tgz ksec README.md LICENSE plugin.yaml
 	GOOS=darwin GOARCH=amd64 go build -o ksec ./cmd/ksec/
-	tar -zcvf $(DIST)/ksec-macos-$(VERSION).tgz ksec README.md LICENSE plugin.yaml
+	tar -zcvf $(DIST)/ksec-macos-$(VERSION)-amd64.tgz ksec README.md LICENSE plugin.yaml
+	GOOS=darwin GOARCH=arm64 go build -o ksec ./cmd/ksec/
+	tar -zcvf $(DIST)/ksec-macos-$(VERSION)-arm64.tgz ksec README.md LICENSE plugin.yaml
 	GOOS=windows GOARCH=amd64 go build -o ksec.exe ./cmd/ksec/
 	tar -zcvf $(DIST)/ksec-windows-$(VERSION).tgz ksec.exe README.md LICENSE plugin.yaml
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/10gen-ops/ksec
 
-go 1.12
+go 1.17
 
 require (
 	github.com/mitchellh/go-homedir v1.1.0
@@ -9,4 +9,41 @@ require (
 	k8s.io/api v0.0.0-20190620084959-7cf5895f2711
 	k8s.io/apimachinery v0.0.0-20190612205821-1799e75a0719
 	k8s.io/client-go v0.0.0-20190620085101-78d2af792bab
+)
+
+require (
+	cloud.google.com/go v0.34.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/evanphx/json-patch v0.0.0-20190203023257-5858425f7550 // indirect
+	github.com/fsnotify/fsnotify v1.4.7 // indirect
+	github.com/gogo/protobuf v1.2.1 // indirect
+	github.com/golang/protobuf v1.3.1 // indirect
+	github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf // indirect
+	github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/imdario/mergo v0.3.5 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/json-iterator/go v0.0.0-20180701071628-ab8a2e0c74be // indirect
+	github.com/magiconair/properties v1.8.0 // indirect
+	github.com/mitchellh/mapstructure v1.1.2 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/pelletier/go-toml v1.2.0 // indirect
+	github.com/spf13/afero v1.1.2 // indirect
+	github.com/spf13/cast v1.3.0 // indirect
+	github.com/spf13/jwalterweatherman v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.3 // indirect
+	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 // indirect
+	golang.org/x/net v0.0.0-20190522155817-f3200d17e092 // indirect
+	golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a // indirect
+	golang.org/x/sys v0.0.0-20190312061237-fead79001313 // indirect
+	golang.org/x/text v0.3.1-0.20181227161524-e6919f6577db // indirect
+	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
+	google.golang.org/appengine v1.5.0 // indirect
+	gopkg.in/inf.v0 v0.9.0 // indirect
+	gopkg.in/yaml.v2 v2.2.2 // indirect
+	k8s.io/klog v0.3.1 // indirect
+	k8s.io/kube-openapi v0.0.0-20190228160746-b3a7cee44a30 // indirect
+	k8s.io/utils v0.0.0-20190221042446-c2654d5206da // indirect
+	sigs.k8s.io/yaml v1.1.0 // indirect
 )


### PR DESCRIPTION
No code changes just make and go.mod. I will cut a 0.1.3-darwin-arm-beta release to publish just the 0.1.3 macos-arm binary tar once this is merged. 

* add the arm64 target for darwin
* move to go 1.17 for darwin arm support
* go mod tidy