### PR TITLE
KANOPY-85 Support macos-arm64, fix download URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,13 @@ build:
 dist:
 	mkdir -p $(DIST)
 	GOOS=linux GOARCH=amd64 go build -o ksec ./cmd/ksec/
-	tar -zcvf $(DIST)/ksec-linux-amd64.tgz ksec README.md LICENSE plugin.yaml
+	tar -zcvf $(DIST)/ksec-linux-amd64-$(VERSION).tgz ksec README.md LICENSE plugin.yaml
 	GOOS=darwin GOARCH=amd64 go build -o ksec ./cmd/ksec/
-	tar -zcvf $(DIST)/ksec-macos-amd64.tgz ksec README.md LICENSE plugin.yaml
+	tar -zcvf $(DIST)/ksec-macos-amd64-$(VERSION).tgz ksec README.md LICENSE plugin.yaml
 	GOOS=darwin GOARCH=arm64 go build -o ksec ./cmd/ksec/
-	tar -zcvf $(DIST)/ksec-macos-arm64.tgz ksec README.md LICENSE plugin.yaml
+	tar -zcvf $(DIST)/ksec-macos-arm64-$(VERSION).tgz ksec README.md LICENSE plugin.yaml
 	GOOS=windows GOARCH=amd64 go build -o ksec.exe ./cmd/ksec/
-	tar -zcvf $(DIST)/ksec-windows-amd64.tgz ksec.exe README.md LICENSE plugin.yaml
+	tar -zcvf $(DIST)/ksec-windows-amd64-$(VERSION).tgz ksec.exe README.md LICENSE plugin.yaml
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,13 @@ build:
 dist:
 	mkdir -p $(DIST)
 	GOOS=linux GOARCH=amd64 go build -o ksec ./cmd/ksec/
-	tar -zcvf $(DIST)/ksec-linux-$(VERSION).tgz ksec README.md LICENSE plugin.yaml
+	tar -zcvf $(DIST)/ksec-linux-amd64.tgz ksec README.md LICENSE plugin.yaml
 	GOOS=darwin GOARCH=amd64 go build -o ksec ./cmd/ksec/
-	tar -zcvf $(DIST)/ksec-macos-$(VERSION)-amd64.tgz ksec README.md LICENSE plugin.yaml
+	tar -zcvf $(DIST)/ksec-macos-amd64.tgz ksec README.md LICENSE plugin.yaml
 	GOOS=darwin GOARCH=arm64 go build -o ksec ./cmd/ksec/
-	tar -zcvf $(DIST)/ksec-macos-$(VERSION)-arm64.tgz ksec README.md LICENSE plugin.yaml
+	tar -zcvf $(DIST)/ksec-macos-arm64.tgz ksec README.md LICENSE plugin.yaml
 	GOOS=windows GOARCH=amd64 go build -o ksec.exe ./cmd/ksec/
-	tar -zcvf $(DIST)/ksec-windows-$(VERSION).tgz ksec.exe README.md LICENSE plugin.yaml
+	tar -zcvf $(DIST)/ksec-windows-amd64.tgz ksec.exe README.md LICENSE plugin.yaml
 
 .PHONY: clean
 clean:

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version sets the release version for ksec
-const Version = "0.1.3"
+const Version = "0.1.4"

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "ksec"
-version: "0.1.3"
+version: "0.1.4"
 usage: "Manage Kubernetes Secrets through Helm"
 description: "Helm plugin that simplifies the management of Kubernetes Secrets"
 ignoreFlags: false

--- a/scripts/install-binary.sh
+++ b/scripts/install-binary.sh
@@ -69,7 +69,15 @@ verifySupported() {
 
 # getDownloadURL checks the latest available version.
 getDownloadURL() {
-  DOWNLOAD_URL="https://github.com/$PROJECT_GH/releases/latest/download/ksec-$OS-$ARCH.tgz"
+  local latest_url="https://api.github.com/repos/$PROJECT_GH/releases/latest"
+  local version
+  if type "curl" > /dev/null; then
+    version=$(curl -s $latest_url | awk '/\"tag_name\":/{gsub( /[,\"]/,"", $2); print $2}')
+  elif type "wget" > /dev/null; then
+    version=$(wget -q -O - $latest_url | awk '/\"tag_name\":/{gsub( /[,\"]/,"", $2); print $2}')
+  fi
+
+  DOWNLOAD_URL="https://github.com/$PROJECT_GH/releases/download/$version/$PROJECT_NAME-$OS-$ARCH-$version.tgz"
 }
 
 # downloadFile downloads the latest binary package and also the checksum

--- a/scripts/install-binary.sh
+++ b/scripts/install-binary.sh
@@ -48,13 +48,14 @@ initOS() {
     # Minimalist GNU for Windows
     mingw*) OS='windows';;
     darwin) OS='macos';;
+    linux) OS='linux';;
   esac
 }
 
 # verifySupported checks that the os/arch combination is supported for
 # binary builds.
 verifySupported() {
-  local supported="linux-amd64\nmacos-amd64\nwindows-amd64"
+  local supported="linux-amd64\nmacos-amd64\nmacos-arm64\nwindows-amd64"
   if ! echo "${supported}" | grep -q "${OS}-${ARCH}"; then
     echo "No prebuild binary for ${OS}-${ARCH}."
     exit 1
@@ -68,13 +69,7 @@ verifySupported() {
 
 # getDownloadURL checks the latest available version.
 getDownloadURL() {
-  # Use the GitHub API to find the latest version for this project.
-  local latest_url="https://api.github.com/repos/$PROJECT_GH/releases/latest"
-  if type "curl" > /dev/null; then
-    DOWNLOAD_URL=$(curl -s $latest_url | grep $OS | awk '/\"browser_download_url\":/{gsub( /[,\"]/,"", $2); print $2}')
-  elif type "wget" > /dev/null; then
-    DOWNLOAD_URL=$(wget -q -O - $latest_url | awk '/\"browser_download_url\":/{gsub( /[,\"]/,"", $2); print $2}')
-  fi
+  DOWNLOAD_URL="https://github.com/$PROJECT_GH/releases/latest/download/ksec-$OS-$ARCH.tgz"
 }
 
 # downloadFile downloads the latest binary package and also the checksum

--- a/scripts/install-binary.sh
+++ b/scripts/install-binary.sh
@@ -69,6 +69,7 @@ verifySupported() {
 
 # getDownloadURL checks the latest available version.
 getDownloadURL() {
+  # Use the GitHub API to find the latest version for this project.
   local latest_url="https://api.github.com/repos/$PROJECT_GH/releases/latest"
   local version
   if type "curl" > /dev/null; then


### PR DESCRIPTION
User reports that the previous [change](https://github.com/10gen-ops/ksec/pull/6), the macos-arm64 binary was built correctly but the install on `helm plugin install https://github.com/10gen-ops/ksec`errors with `No prebuild binary for macos-arm64.`.
Also a different issue, when I try to install on my macos-amd64 machine, the curl step fails because the command to generate the download url includes the [sha256 file](https://github.com/10gen-ops/ksec/releases), resulting in an invalid url.

So this change fixes:
- add `macos-arm64` to supported list
- change the construction of DOWNLOAD_URL. Instead of looking through the browser_download_url, construct the path using version.

I'll need to cut a new release `0.1.4` with these assets:
ksec-linux-amd64-0.1.4.tgz
ksec-macos-amd64-0.1.4.tgz
ksec-macos-arm64-0.1.4.tgz
ksec-windows-amd64-0.1.4.tgz

From now on, the release tag must match the pkg/version/version.go `Version`


### Testing
I'll need to cut the new release with file assets before I can test (I think).
I tried `helm plugin install .` on this branch, and I can at least see the download_url path is correct but the file assets aren't there since I haven't cut new release with new naming convention.