### PR TITLE
DEVOPS-1505 fix index out of range panic

### DIFF
--- a/cmd/ksec/push.go
+++ b/cmd/ksec/push.go
@@ -42,9 +42,11 @@ func scanSecretData(reader io.Reader, data map[string][]byte) error {
 	scanner := bufio.NewScanner(reader)
 
 	for scanner.Scan() {
-		text := scanner.Text()
-		split := strings.SplitN(text, "=", 2)
-		data[split[0]] = []byte(split[1])
+		split := strings.SplitN(scanner.Text(), "=", 2)
+
+		if len(split) > 1 {
+			data[split[0]] = []byte(split[1])
+		}
 	}
 
 	return scanner.Err()

--- a/cmd/ksec/push.go
+++ b/cmd/ksec/push.go
@@ -19,7 +19,6 @@ var pushCmd = &cobra.Command{
 func pushCommand(cmd *cobra.Command, args []string) error {
 	fileArg := args[0]
 	secretName := args[1]
-	data := make(map[string][]byte)
 
 	file, err := os.Open(fileArg)
 	if err != nil {
@@ -27,7 +26,8 @@ func pushCommand(cmd *cobra.Command, args []string) error {
 	}
 	defer file.Close()
 
-	if err := scanSecretData(file, data); err != nil {
+	data, err := readSecretData(file)
+	if err != nil {
 		return err
 	}
 
@@ -38,7 +38,8 @@ func pushCommand(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func scanSecretData(reader io.Reader, data map[string][]byte) error {
+func readSecretData(reader io.Reader) (map[string][]byte, error) {
+	data := map[string][]byte{}
 	scanner := bufio.NewScanner(reader)
 
 	for scanner.Scan() {
@@ -49,5 +50,9 @@ func scanSecretData(reader io.Reader, data map[string][]byte) error {
 		}
 	}
 
-	return scanner.Err()
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return data, nil
 }

--- a/cmd/ksec/push_test.go
+++ b/cmd/ksec/push_test.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestScanSecretData(t *testing.T) {
+	reader := strings.NewReader(`key=value`)
+	data := map[string][]byte{}
+
+	assert.NoError(t, scanSecretData(reader, data))
+	assert.Equal(t, "value", string(data["key"]))
+}

--- a/cmd/ksec/push_test.go
+++ b/cmd/ksec/push_test.go
@@ -16,9 +16,10 @@ key1=
 key2=value2
 key3
 `)
-	data := map[string][]byte{}
 
-	assert.NoError(t, scanSecretData(reader, data))
+	data, err := readSecretData(reader)
+	assert.NoError(t, err)
+
 	assert.Equal(t, "value", string(data["key"]))
 	assert.Equal(t, "", string(data["key1"]))
 	assert.Equal(t, "value2", string(data["key2"]))

--- a/cmd/ksec/push_test.go
+++ b/cmd/ksec/push_test.go
@@ -8,9 +8,21 @@ import (
 )
 
 func TestScanSecretData(t *testing.T) {
-	reader := strings.NewReader(`key=value`)
+	t.Parallel()
+
+	reader := strings.NewReader(`
+key=value
+key1=
+key2=value2
+key3
+`)
 	data := map[string][]byte{}
 
 	assert.NoError(t, scanSecretData(reader, data))
 	assert.Equal(t, "value", string(data["key"]))
+	assert.Equal(t, "", string(data["key1"]))
+	assert.Equal(t, "value2", string(data["key2"]))
+
+	_, ok := data["key3"]
+	assert.False(t, ok)
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/viper v1.4.0
+	github.com/stretchr/testify v1.2.2
 	k8s.io/api v0.0.0-20190620084959-7cf5895f2711
 	k8s.io/apimachinery v0.0.0-20190612205821-1799e75a0719
 	k8s.io/client-go v0.0.0-20190620085101-78d2af792bab
@@ -29,6 +30,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/pelletier/go-toml v1.2.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/afero v1.1.2 // indirect
 	github.com/spf13/cast v1.3.0 // indirect
 	github.com/spf13/jwalterweatherman v1.0.0 // indirect


### PR DESCRIPTION
Fixes issue in `ksec push` where lines with no `=` or with empty values cause an index out of range panic.